### PR TITLE
Package.swift support

### DIFF
--- a/snippets.sh
+++ b/snippets.sh
@@ -165,9 +165,13 @@ printUsage () {
 
 # Ensure our globals are cleared before populating with args
 unset -v IS_DEBUG
+unset -v IS_DRYRUN
 unset -v IS_ADMIN
 unset -v LIST_AUTHORS
 unset -v TYPE
+INDENT='  '
+NEWLINE='
+'
 
 # Parses script arguments which take the form of:
 #   * --key=value
@@ -252,6 +256,12 @@ while [[ $# -gt 0 ]]; do
       # This arg was processed at the top of the script, so not much to do in this case.
       logdStdErr "Found $1 arg"
       IS_DEBUG="$1"
+      ;;
+    --dry-run)
+      # Looks for presence of --dry-run
+      # This arg was processed at the top of the script, so not much to do in this case.
+      logdStdErr "Found $1 arg"
+      IS_DRYRUN="$1"
       ;;
     --admin)
       # Looks for presence of --admin
@@ -500,7 +510,7 @@ elif [[ "$MODE" == 'backup' ]]; then
         logdStdErr -red "  discarded_snippet_source_files[$i]: $discarded_snippet_source_file" --default
       done
       
-      return 0
+      # return 0
 
 
   #     cat "$FILE" | grep "<key>IDECodeSnippetTitle</key>
@@ -509,16 +519,56 @@ elif [[ "$MODE" == 'backup' ]]; then
       # logdStdErr "snippets: ${snippets[@]}"
 
 
-      snippets=()
+      # retained_snippet_source_files=()
+
+      # retained_snippet_source_files=("$@")
+      logdStdErr "retained_snippet_source_files.count: ${#retained_snippet_source_files[@]}"
+      for ((i=0; i<="${#retained_snippet_source_files[@]}"; i++)); do
+        retained_snippet_source_file="${retained_snippet_source_files[$i]}"
+        if [[ -z "$retained_snippet_source_file" ]]; then continue; fi
+        logdStdErr "\${retained_snippet_source_files[$i]}: $retained_snippet_source_file"
+
+        snippet_basename=$(basename "${retained_snippet_source_file}")
+        snippet_title=$(/usr/libexec/PlistBuddy -c "print :IDECodeSnippetTitle" "${retained_snippet_source_file}")
+        corrected_snippet_basename="${snippet_title}.codesnippet"
+        snippet_dest_file="${REPO_SNIPPETS_DIR}/${corrected_filename}"
+        rename_and_copy_command="cp \"$retained_snippet_source_file\" \"$snippet_dest_file}\""
+
+        logdStdErr "  snippet_basename: ${snippet_basename}"
+        logdStdErr "  snippet_title: ${snippet_title}"
+        logdStdErr "  corrected_snippet_basename: ${corrected_snippet_basename}"
+        logdStdErr "  snippet_basename: ${snippet_basename}"
+        logdStdErr "  snippet_dest_file: ${snippet_dest_file}"
+        logdStdErr "  rename_and_copy_command: ${rename_and_copy_command}"
+        # if [[ "${filename}" != "${corrected_filename}" ]]; then 
+          logStdErr "  renaming file: ${filename} to ${corrected_filename}"
+        # fi
+
+        if [[ -n "$IS_DRYRUN" ]]; then 
+           echo -e "\x1B[93m\x1B[1m  ${rename_and_copy_command}\x1B[0m\x1B[2m # dry-run\x1B[0m" 2>&1
+        else 
+          rename_and_copy_output="$(eval "$rename_and_copy_command")"
+          rename_and_copy_rval=$?
+          logdStdErr "  rename_and_copy_output: ${rename_and_copy_output}"
+          logdStdErr "  rename_and_copy_rval: ${rename_and_copy_rval}"
+          
+          if [[ $rename_and_copy_rval -ne 0 ]]; then
+            echo -e "\x1B[91m\x1B[1m  [ERROR]\x1B[0m Failed to rename and copy${NEWLINE}" \
+              "${INDENT}${INDENT}command: \x1B[93m\x1B[1m${rename_and_copy_command}\x1B[0m${NEWLINE}" \
+              "${INDENT}${INDENT}exit status: \x1B[91m[${rename_and_copy_rval}]\x1B[0m" 2>&1
+          fi
+        fi
+      done
+      
 
       # ensure that each snippet file is named the same as defined within the file. 
-      for (( i=0; i<"${#snippets[@]}"; i++)); do
-        filename=$(basename "${snippets[$i]}")
-        snippettitle=$(/usr/libexec/PlistBuddy -c "print :IDECodeSnippetTitle" "${snippets[$i]}")
+      for (( i=0; i<"${#retained_snippet_source_files[@]}"; i++)); do
+        filename=$(basename "${retained_snippet_source_files[$i]}")
+        snippettitle=$(/usr/libexec/PlistBuddy -c "print :IDECodeSnippetTitle" "${retained_snippet_source_files[$i]}")
         corrected_filename="${snippettitle}.codesnippet"
-        command="cp \"${snippets[$i]}\" \"${REPO_SNIPPETS_DIR}/${corrected_filename}\""
+        command="cp \"${retained_snippet_source_files[$i]}\" \"${REPO_SNIPPETS_DIR}/${corrected_filename}\""
 
-        logdStdErr "snippets[$i]:"
+        logdStdErr "retained_snippet_source_files[$i]:"
         logdStdErr "  filename: ${filename}"
         logdStdErr "  corrected_filename: ${corrected_filename}"
         if [[ "${filename}" != "${corrected_filename}" ]]; then 

--- a/snippets.sh
+++ b/snippets.sh
@@ -1,4 +1,21 @@
-#!/bin/bash
+#!/bin/zsh
+# shellcheck shell=bash
+# ---- ---- ----  About this Script  ---- ---- ----
+#
+# <!-- TODO: this script does... -->
+#
+# ---- ---- ---- ----  Imports  ---- ---- ---- ----
+# set -e
+# # shellcheck disable=SC1091
+# source "$HOME/.zsh_home/utilities/.zsh_scripting_utilities" "$0" "$@" > /dev/null
+# set +e
+# ---- ---- ----   Argument Parsing   ---- ---- ----
+
+# ---- ---- ----     Script Work     ---- ---- ----
+
+
+
+
 
 
 # -------- BEGIN META NOTES --------
@@ -326,6 +343,7 @@ elif [[ "$IDE" == 'vscode' ]]; then
   SNIPPET_EXTENSIONS=("code-snippets" "json")
 fi
 
+
 # Check if dirs exist before using them
 if [[ -d "$REPO_SNIPPETS_DIR" ]]; then 
   logdStdErr "  REPO_SNIPPETS_DIR was located: $REPO_SNIPPETS_DIR"
@@ -364,13 +382,13 @@ elif [[ "$MODE" == 'rename' ]]; then
     # ensure that each snippet file is named the same as defined within the file. 
     for (( i=0; i<"${#snippets[@]}"; i++)); do
       filename=$(basename "${snippets[$i]}")
-      snippetname=$(/usr/libexec/PlistBuddy -c "print :IDECodeSnippetTitle" "${snippets[$i]}")
-      corrected_filename="${snippetname}.codesnippet"
+      snippettitle=$(/usr/libexec/PlistBuddy -c "print :IDECodeSnippetTitle" "${snippets[$i]}")
+      corrected_filename="${snippettitle}.codesnippet"
       command="mv \"${snippets[$i]}\" \"${CLIENT_SNIPPETS_DIR}/${corrected_filename}\""
 
       if [[ "${filename}" != "${corrected_filename}" ]]; then 
         logdStdErr "snippets[$i]:"
-        # logdStdErr "  snippet: ${snippetname}"
+        # logdStdErr "  snippet: ${snippettitle}"
         logdStdErr "  filename: ${filename}"
         logdStdErr "  corrected_filename: ${corrected_filename}"
         logdStdErr "  command: ${command}"
@@ -394,7 +412,7 @@ elif [[ "$MODE" == 'install' || "$MODE" == 'install-clean' ]]; then
       find "${CLIENT_SNIPPETS_DIR}" -maxdepth 1 -type f -print0 | xargs -0 -I {} cp {} "${BACKUP_DIR}"
       logStdErr "Did copy existing ${IDE} snippets to backup dir: ${ANSI_FILEPATH}${BACKUP_DIR}${ANSI_DEFAULT}"
     elif [[ "$MODE" == 'install-clean' ]]; then
-      # FIXME: zakkhoyt. condider only deleting those files where either filename or snippetname begins with TEAM_PREFIX      
+      # FIXME: zakkhoyt. condider only deleting those files where either filename or snippettitle begins with TEAM_PREFIX      
       find "${CLIENT_SNIPPETS_DIR}" -maxdepth 1 -type f -print0 | xargs -0 -I {} mv {} "${BACKUP_DIR}"
       logStdErr "Did move existing ${IDE} snippets to backup dir: ${ANSI_FILEPATH}${BACKUP_DIR}${ANSI_DEFAULT}"
     else
@@ -434,18 +452,70 @@ elif [[ "$MODE" == 'backup' ]]; then
       # for xcode we want to rename the files as they are being copied
 
       # Get array of snippet files
-      snippets=()
+      snippet_source_files=()
+      # while IFS=  read -r -d $'\0'; do
+      #     snippet_source_files+=("$REPLY")
+      # done < <(find "${CLIENT_SNIPPETS_DIR}" -maxdepth 1 -type f -name "${TEAM_PREFIX}*.${SNIPPET_EXTENSION}" -print0)
       while IFS=  read -r -d $'\0'; do
-          snippets+=("$REPLY")
-      done < <(find "${CLIENT_SNIPPETS_DIR}" -maxdepth 1 -type f -name "${TEAM_PREFIX}*.${SNIPPET_EXTENSION}" -print0)
+          snippet_source_files+=("$REPLY")
+      done < <(find "${CLIENT_SNIPPETS_DIR}" -maxdepth 1 -type f -name "*.${SNIPPET_EXTENSION}" -print0)
+      logdStdErr "snippet_source_files.count: ${#snippet_source_files[@]}"
+
+
+      # Either retain or discard each
+      retained_snippet_source_files=()
+      discarded_snippet_source_files=("$@")
+      for ((i=0; i<="${#snippet_source_files[@]}"; i++)); do
+        snippet_source_file="${snippet_source_files[$i]}"
+        if [[ -z "$snippet_source_file" ]]; then continue; fi
+        logdStdErr "  snippet_source_files[$i]: $snippet_source_file"
+
+        snippet_basename=$(basename "${snippet_source_file}")
+        logdStdErr "    snippet_basename: $snippet_basename"
+        snippet_title=$(/usr/libexec/PlistBuddy -c "print :IDECodeSnippetTitle" "$snippet_source_file")
+        logdStdErr "    snippet_title: $snippet_title"
+
+        if [[ "$snippet_source_file" == "${TEAM_PREFIX}"*".${SNIPPET_EXTENSION}" ]]; then 
+          logdStdErr "        snippet_basename: contains ${TEAM_PREFIX}. Retaining..."
+          retained_snippet_source_files=("${retained_snippet_source_files[@]}" "$snippet_source_file")
+        elif [[ "$snippet_title" == "${TEAM_PREFIX}"* ]]; then 
+          logdStdErr "        snippet_title: contains ${TEAM_PREFIX}. Retaining..."
+          retained_snippet_source_files=("${retained_snippet_source_files[@]}" "$snippet_source_file")
+        else
+          logdStdErr "    snippet does not refer to ${TEAM_PREFIX}. Discarding..."
+        fi
+      done
+      
+      logdStdErr "retained_snippet_source_files.count: ${#retained_snippet_source_files[@]}"
+      for ((i=0; i<="${#retained_snippet_source_files[@]}"; i++)); do
+        retained_snippet_source_file="${retained_snippet_source_files[$i]}"
+        if [[ -z "$retained_snippet_source_file" ]]; then continue; fi
+        logdStdErr --green "  retained_snippet_source_files[$i]: $retained_snippet_source_file" --default
+      done
+
+      logdStdErr "discarded_snippet_source_files.count: ${#discarded_snippet_source_files[@]}"
+      for ((i=0; i<="${#discarded_snippet_source_files[@]}"; i++)); do
+        discarded_snippet_source_file="${discarded_snippet_source_files[$i]}"
+        if [[ -z "$discarded_snippet_source_file" ]]; then continue; fi
+        logdStdErr -red "  discarded_snippet_source_files[$i]: $discarded_snippet_source_file" --default
+      done
+      
+      return 0
+
+
+  #     cat "$FILE" | grep "<key>IDECodeSnippetTitle</key>
+	# <string>${TEAM_PREFIX}"
       
       # logdStdErr "snippets: ${snippets[@]}"
+
+
+      snippets=()
 
       # ensure that each snippet file is named the same as defined within the file. 
       for (( i=0; i<"${#snippets[@]}"; i++)); do
         filename=$(basename "${snippets[$i]}")
-        snippetname=$(/usr/libexec/PlistBuddy -c "print :IDECodeSnippetTitle" "${snippets[$i]}")
-        corrected_filename="${snippetname}.codesnippet"
+        snippettitle=$(/usr/libexec/PlistBuddy -c "print :IDECodeSnippetTitle" "${snippets[$i]}")
+        corrected_filename="${snippettitle}.codesnippet"
         command="cp \"${snippets[$i]}\" \"${REPO_SNIPPETS_DIR}/${corrected_filename}\""
 
         logdStdErr "snippets[$i]:"

--- a/snippets.sh
+++ b/snippets.sh
@@ -531,8 +531,8 @@ elif [[ "$MODE" == 'backup' ]]; then
         snippet_basename=$(basename "${retained_snippet_source_file}")
         snippet_title=$(/usr/libexec/PlistBuddy -c "print :IDECodeSnippetTitle" "${retained_snippet_source_file}")
         corrected_snippet_basename="${snippet_title}.codesnippet"
-        snippet_dest_file="${REPO_SNIPPETS_DIR}/${corrected_filename}"
-        rename_and_copy_command="cp \"$retained_snippet_source_file\" \"$snippet_dest_file}\""
+        snippet_dest_file="${REPO_SNIPPETS_DIR}/${corrected_snippet_basename}"
+        rename_and_copy_command="cp \"$retained_snippet_source_file\" \"${snippet_dest_file}\""
 
         logdStdErr "  snippet_basename: ${snippet_basename}"
         logdStdErr "  snippet_title: ${snippet_title}"
@@ -541,7 +541,7 @@ elif [[ "$MODE" == 'backup' ]]; then
         logdStdErr "  snippet_dest_file: ${snippet_dest_file}"
         logdStdErr "  rename_and_copy_command: ${rename_and_copy_command}"
         # if [[ "${filename}" != "${corrected_filename}" ]]; then 
-          logStdErr "  renaming file: ${filename} to ${corrected_filename}"
+          # logStdErr "  renaming file: ${retained_snippet_source_file} to ${snippet_dest_file}"
         # fi
 
         if [[ -n "$IS_DRYRUN" ]]; then 
@@ -561,21 +561,21 @@ elif [[ "$MODE" == 'backup' ]]; then
       done
       
 
-      # ensure that each snippet file is named the same as defined within the file. 
-      for (( i=0; i<"${#retained_snippet_source_files[@]}"; i++)); do
-        filename=$(basename "${retained_snippet_source_files[$i]}")
-        snippettitle=$(/usr/libexec/PlistBuddy -c "print :IDECodeSnippetTitle" "${retained_snippet_source_files[$i]}")
-        corrected_filename="${snippettitle}.codesnippet"
-        command="cp \"${retained_snippet_source_files[$i]}\" \"${REPO_SNIPPETS_DIR}/${corrected_filename}\""
+      # # ensure that each snippet file is named the same as defined within the file. 
+      # for (( i=0; i<"${#retained_snippet_source_files[@]}"; i++)); do
+      #   filename=$(basename "${retained_snippet_source_files[$i]}")
+      #   snippettitle=$(/usr/libexec/PlistBuddy -c "print :IDECodeSnippetTitle" "${retained_snippet_source_files[$i]}")
+      #   corrected_filename="${snippettitle}.codesnippet"
+      #   command="cp \"${retained_snippet_source_files[$i]}\" \"${REPO_SNIPPETS_DIR}/${corrected_filename}\""
 
-        logdStdErr "retained_snippet_source_files[$i]:"
-        logdStdErr "  filename: ${filename}"
-        logdStdErr "  corrected_filename: ${corrected_filename}"
-        if [[ "${filename}" != "${corrected_filename}" ]]; then 
-          logStdErr "  renaming file: ${filename} to ${corrected_filename}"
-        fi
-        eval "$command"
-      done
+      #   logdStdErr "retained_snippet_source_files[$i]:"
+      #   logdStdErr "  filename: ${filename}"
+      #   logdStdErr "  corrected_filename: ${corrected_filename}"
+      #   if [[ "${filename}" != "${corrected_filename}" ]]; then 
+      #     logStdErr "  renaming file: ${filename} to ${corrected_filename}"
+      #   fi
+      #   eval "$command"
+      # done
     else 
       set -x
       cp "${CLIENT_SNIPPETS_DIR}/${TEAM_PREFIX}"*."${SNIPPET_EXTENSION}" "${REPO_SNIPPETS_DIR}"

--- a/snippets.sh
+++ b/snippets.sh
@@ -493,6 +493,7 @@ elif [[ "$MODE" == 'backup' ]]; then
           retained_snippet_source_files=("${retained_snippet_source_files[@]}" "$snippet_source_file")
         else
           logdStdErr "    snippet does not refer to ${TEAM_PREFIX}. Discarding..."
+          discarded_snippet_source_files=("${discarded_snippet_source_files[@]}" "$snippet_source_file")
         fi
       done
       
@@ -500,14 +501,16 @@ elif [[ "$MODE" == 'backup' ]]; then
       for ((i=0; i<="${#retained_snippet_source_files[@]}"; i++)); do
         retained_snippet_source_file="${retained_snippet_source_files[$i]}"
         if [[ -z "$retained_snippet_source_file" ]]; then continue; fi
-        logdStdErr --green "  retained_snippet_source_files[$i]: $retained_snippet_source_file" --default
+        # logdStdErr --green "  retained_snippet_source_files[$i]: $retained_snippet_source_file" --default
+        echo -e "\x1B[92m  retained_snippet_source_files[$i]: $retained_snippet_source_file\x1B[0m" 1>&2
       done
 
       logdStdErr "discarded_snippet_source_files.count: ${#discarded_snippet_source_files[@]}"
       for ((i=0; i<="${#discarded_snippet_source_files[@]}"; i++)); do
         discarded_snippet_source_file="${discarded_snippet_source_files[$i]}"
         if [[ -z "$discarded_snippet_source_file" ]]; then continue; fi
-        logdStdErr -red "  discarded_snippet_source_files[$i]: $discarded_snippet_source_file" --default
+        # logdStdErr -red "  discarded_snippet_source_files[$i]: $discarded_snippet_source_file" --default
+        echo -e "\x1B[31m  discarded_snippet_source_files[$i]: $discarded_snippet_source_file\x1B[0m" 1>&2
       done
       
       # return 0

--- a/source/xcode/hatch_comment_linters_de_all.codesnippet
+++ b/source/xcode/hatch_comment_linters_de_all.codesnippet
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>__delintall</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>// swiftformat:disable all
+// swiftlint:disable
+// swiftlint:enable
+// swiftformat:enable all</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>7B16C5B4-56D7-4D1C-B3C3-D75F6FC49156</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string>Disable/Enable all lint rules</string>
+	<key>IDECodeSnippetTitle</key>
+	<string>hatch_comment_linters_de_all</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/source/xcode/hatch_compactMap_values.codesnippet
+++ b/source/xcode/hatch_compactMap_values.codesnippet
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>__compactMapValues</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>.compactMapValues { $0 }</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>8D263C86-6C64-4C92-ACCB-BA92507B4019</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string>compactMapValues { $0 }</string>
+	<key>IDECodeSnippetTitle</key>
+	<string>hatch_compactMap_values</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/source/xcode/hatch_string_describing.codesnippet
+++ b/source/xcode/hatch_string_describing.codesnippet
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>__strdesc</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>String(describing: &lt;#item#&gt;)</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>614163B2-FA98-44F9-9728-C7BCA23481C1</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string>String(describing:)</string>
+	<key>IDECodeSnippetTitle</key>
+	<string>hatch_string_describing</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/source/xcode/hatch_string_reflecting.codesnippet
+++ b/source/xcode/hatch_string_reflecting.codesnippet
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>__strrefl</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>String(reflecting: &lt;#item#&gt;)</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>9AC82CC0-9E62-457F-B7D7-E67BF131A2F9</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string>String(reflecting: )</string>
+	<key>IDECodeSnippetTitle</key>
+	<string>hatch_string_reflecting</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/source/xcode/hatch_swift_package_binary_target.codesnippet
+++ b/source/xcode/hatch_swift_package_binary_target.codesnippet
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>__spbt</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>.binaryTarget(
+    name: &lt;#T##String#&gt;,
+    path: &lt;#T##String#&gt;
+    )</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>18A65635-C982-49DA-AECC-B7556DAA0D29</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string></string>
+	<key>IDECodeSnippetTitle</key>
+	<string>hatch_swift_package_binary_target</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/source/xcode/hatch_swift_package_executable_target.codesnippet
+++ b/source/xcode/hatch_swift_package_executable_target.codesnippet
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>__spet</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>.executableTarget(
+    name: &lt;#T##String#&gt;,
+    dependencies: &lt;#T##[Target.Dependency]#&gt;,
+    path: &lt;#T##String?#&gt;,
+    exclude: &lt;#T##[String]#&gt;,
+    sources: &lt;#T##[String]?#&gt;,
+    resources: &lt;#T##[Resource]?#&gt;,
+    publicHeadersPath: &lt;#T##String?#&gt;,
+    packageAccess: &lt;#T##Bool#&gt;,
+    cSettings: &lt;#T##[CSetting]?#&gt;,
+    cxxSettings: &lt;#T##[CXXSetting]?#&gt;,
+    swiftSettings: &lt;#T##[SwiftSetting]?#&gt;,
+    linkerSettings: &lt;#T##[LinkerSetting]?#&gt;,
+    plugins: &lt;#T##[Target.PluginUsage]?#&gt;
+    )</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>547644D2-DE24-4031-807A-C95E4EFAA0E8</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string>All placeholders for an executableTarget in Package.swift</string>
+	<key>IDECodeSnippetTitle</key>
+	<string>hatch_swift_package_executable_target</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/source/xcode/hatch_swift_package_library.codesnippet
+++ b/source/xcode/hatch_swift_package_library.codesnippet
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>__splib</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>.library(
+    name: &lt;#T##String#&gt;,
+    type: &lt;#T##.static|.dynamic#&gt;,
+    targets: &lt;#T##[String]#&gt;
+)</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>B7A450B3-2088-4F52-BD56-2DED9B7883FC</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string></string>
+	<key>IDECodeSnippetTitle</key>
+	<string>hatch_swift_package_library</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/source/xcode/hatch_swift_package_target.codesnippet
+++ b/source/xcode/hatch_swift_package_target.codesnippet
@@ -23,7 +23,7 @@
             swiftSettings: &lt;#T##[SwiftSetting]?#&gt;,
             linkerSettings: &lt;#T##[LinkerSetting]?#&gt;,
             plugins: &lt;#T##[Target.PluginUsage]?#&gt;
-        )</string>
+        ) </string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>268CE079-BAF1-46CC-A97D-EDF7C8AD336B</string>
 	<key>IDECodeSnippetLanguage</key>

--- a/source/xcode/hatch_swift_package_target.codesnippet
+++ b/source/xcode/hatch_swift_package_target.codesnippet
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string></string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>        .target(
+            name: &lt;#T##String#&gt;,
+            dependencies: &lt;#T##[Target.Dependency]#&gt;,
+            path: &lt;#T##String?#&gt;,
+            exclude: &lt;#T##[String]#&gt;,
+            sources: &lt;#T##[String]?#&gt;,
+            resources: &lt;#T##[Resource]?#&gt;,
+            publicHeadersPath: &lt;#T##String?#&gt;,
+            packageAccess: &lt;#T##Bool#&gt;,
+            cSettings: &lt;#T##[CSetting]?#&gt;,
+            cxxSettings: &lt;#T##[CXXSetting]?#&gt;,
+            swiftSettings: &lt;#T##[SwiftSetting]?#&gt;,
+            linkerSettings: &lt;#T##[LinkerSetting]?#&gt;,
+            plugins: &lt;#T##[Target.PluginUsage]?#&gt;
+        )</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>268CE079-BAF1-46CC-A97D-EDF7C8AD336B</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string>All placeholders for a target in Package.swift </string>
+	<key>IDECodeSnippetTitle</key>
+	<string>hatch_swift_package_target</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>0</integer>
+</dict>
+</plist>

--- a/source/xcode/hatch_swift_testing_traits_bug_github.codesnippet
+++ b/source/xcode/hatch_swift_testing_traits_bug_github.codesnippet
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>__stbuggh</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>    @Test(
+        "&lt;#Test Title#&gt;",
+        .bug(
+            "https://github.com/hatch-baby/HatchSleep-iOS/issues/&lt;#PR#&gt;",
+            "Pull Request #&lt;#PR#&gt;"
+        )
+    )</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>54683F5C-E812-47D6-9F81-FA3163EAB340</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string></string>
+	<key>IDECodeSnippetTitle</key>
+	<string>hatch_swift_testing_traits_bug_github</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/source/xcode/hatch_swift_testing_traits_bug_jira.codesnippet
+++ b/source/xcode/hatch_swift_testing_traits_bug_jira.codesnippet
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>__stbugjira __stbughsd</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>All</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>    @Test(
+        "&lt;#Test Title#&gt;",
+        .bug(
+            "https://hatchbaby.atlassian.net/browse/HSD-&lt;#NNNNN#&gt;"
+            "Jira HSD-&lt;#NNNNN#&gt;"
+        )
+    )</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>0C2D845D-C9F1-45EA-8445-C59D96E116DA</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string></string>
+	<key>IDECodeSnippetTitle</key>
+	<string>hatch_swift_testing_traits_bug_jira</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>2</integer>
+</dict>
+</plist>


### PR DESCRIPTION
Add snippets for Package.swift targets, libraries, products. 


Adds improvement in `./snippets.sh` when backing up xcode snippet files from the defaullt dir to this repo the files are renamed as they are moved if the snippet content is prefixed with `hatch_`. (instead of the UUID names that xcode likes ot use)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiple new Xcode code snippets for Swift, including templates for disabling/enabling linters, common Swift expressions (`compactMapValues`, `String(describing:)`, `String(reflecting:)`), and Swift Package Manager target declarations.
  * Introduced code snippets for annotating Swift tests with bug references (GitHub and Jira).

* **Refactor**
  * Improved snippet backup logic to better filter and rename files based on internal titles and added a dry-run mode for safer operations.

* **Style**
  * Enhanced logging output and variable naming for clarity in script operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->